### PR TITLE
feat[#10]: qna 댓글 CRUD 구현

### DIFF
--- a/src/main/java/com/brick/demo/social/controller/QnaCommentController.java
+++ b/src/main/java/com/brick/demo/social/controller/QnaCommentController.java
@@ -1,0 +1,51 @@
+package com.brick.demo.social.controller;
+
+import com.brick.demo.social.dto.QnaCommentPatchDto;
+import com.brick.demo.social.dto.QnaCommentRequestDto;
+import com.brick.demo.social.dto.QnaCommentResponseDto;
+import com.brick.demo.social.dto.QnaPatchRequestDto;
+import com.brick.demo.social.dto.QnaRequestDto;
+import com.brick.demo.social.dto.QnaResponseDto;
+import com.brick.demo.social.service.QnaCommentService;
+import com.brick.demo.social.service.QnaService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/socials/{socialId}/qnas/{qnaId}/comments")
+public class QnaCommentController {
+
+	private final QnaCommentService qnaCommentService;
+
+	@Autowired
+	QnaCommentController(QnaCommentService qnaCommentService) {
+		this.qnaCommentService = qnaCommentService;
+	}
+
+	@PostMapping
+	public QnaCommentResponseDto create(@PathVariable Long qnaId,
+			@Valid @RequestBody QnaCommentRequestDto dto) {
+		return qnaCommentService.create(qnaId, dto);
+	}
+
+	@PatchMapping("/{commentId}")
+	public QnaCommentResponseDto update(@PathVariable Long commentId,
+			@Valid @RequestBody
+			QnaCommentPatchDto dto) {
+		return qnaCommentService.update(commentId, dto);
+	}
+
+	@DeleteMapping("/{commentId}")
+	public ResponseEntity<Void> delete(@PathVariable Long commentId) {
+		qnaCommentService.delete(commentId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/brick/demo/social/dto/QnaCommentPatchDto.java
+++ b/src/main/java/com/brick/demo/social/dto/QnaCommentPatchDto.java
@@ -1,0 +1,11 @@
+package com.brick.demo.social.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class QnaCommentPatchDto {
+
+	@Size(max = 600, message = "내용은 600자를 넘을 수 없습니다")
+	private String content;
+}

--- a/src/main/java/com/brick/demo/social/dto/QnaCommentRequestDto.java
+++ b/src/main/java/com/brick/demo/social/dto/QnaCommentRequestDto.java
@@ -1,0 +1,20 @@
+package com.brick.demo.social.dto;
+
+import com.brick.demo.auth.entity.Account;
+import com.brick.demo.social.entity.Qna;
+import com.brick.demo.social.entity.QnaComment;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class QnaCommentRequestDto {
+
+	@NotEmpty(message = "내용은 빈 문자열일 수 없습니다")
+	@Size(max = 600, message = "내용은 600자를 넘을 수 없습니다")
+	private String content;
+
+	public QnaComment toEntity(Qna qna, Account writer) {
+		return QnaComment.builder().qna(qna).content(this.content).writer(writer).build();
+	}
+}

--- a/src/main/java/com/brick/demo/social/dto/QnaCommentResponseDto.java
+++ b/src/main/java/com/brick/demo/social/dto/QnaCommentResponseDto.java
@@ -1,13 +1,12 @@
 package com.brick.demo.social.dto;
 
+import com.brick.demo.social.entity.QnaComment;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
-@Builder
 public class QnaCommentResponseDto {
 
 	private Long id;
@@ -15,4 +14,20 @@ public class QnaCommentResponseDto {
 	private String writerName;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
+
+	public QnaCommentResponseDto(QnaComment qnaComment) {
+		this.id = qnaComment.getId();
+		this.content = qnaComment.getContent();
+		this.writerName = qnaComment.getWriter().getName();
+		this.createdAt = qnaComment.getCreatedAt();
+		this.updatedAt = qnaComment.getUpdatedAt();
+	}
+
+	public QnaCommentResponseDto(QnaComment qnaComment, LocalDateTime updatedAt) {
+		this.id = qnaComment.getId();
+		this.content = qnaComment.getContent();
+		this.writerName = qnaComment.getWriter().getName();
+		this.createdAt = qnaComment.getCreatedAt();
+		this.updatedAt = updatedAt;
+	}
 }

--- a/src/main/java/com/brick/demo/social/dto/QnaPatchRequestDto.java
+++ b/src/main/java/com/brick/demo/social/dto/QnaPatchRequestDto.java
@@ -13,6 +13,6 @@ public class QnaPatchRequestDto {
 	@Size(max = 40, message = "제목은 40자를 넘을 수 없습니다")
 	private String title;
 
-	@Size(max = 500, message = "내용은 500자를 넘을 수 없습니다")
+	@Size(max = 600, message = "내용은 600자를 넘을 수 없습니다")
 	private String content;
 }

--- a/src/main/java/com/brick/demo/social/dto/QnaRequestDto.java
+++ b/src/main/java/com/brick/demo/social/dto/QnaRequestDto.java
@@ -18,7 +18,7 @@ public class QnaRequestDto {
 	private String title;
 
 	@NotEmpty(message = "내용은 빈 문자열일 수 없습니다")
-	@Size(max = 500, message = "내용은 500자를 넘을 수 없습니다")
+	@Size(max = 600, message = "내용은 600자를 넘을 수 없습니다")
 	private String content;
 
 	public Qna toEntity(Account writer, Long socialId) {

--- a/src/main/java/com/brick/demo/social/dto/QnaResponseDto.java
+++ b/src/main/java/com/brick/demo/social/dto/QnaResponseDto.java
@@ -34,13 +34,7 @@ public class QnaResponseDto {
 		this.createdAt = qna.getCreatedAt();
 		this.updatedAt = updatedAt; // save한 후 get으로 가져온 값을 넣어줘야 함
 		this.comments = comments.stream()
-				.map(comment -> QnaCommentResponseDto.builder()
-						.id(comment.getId())
-						.content(comment.getContent())
-						.writerName(comment.getWriter().getName())
-						.createdAt(comment.getCreatedAt())
-						.updatedAt(comment.getUpdatedAt())
-						.build())
+				.map(QnaCommentResponseDto::new)
 				.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/brick/demo/social/entity/Qna.java
+++ b/src/main/java/com/brick/demo/social/entity/Qna.java
@@ -42,10 +42,10 @@ public class Qna {
 //  @JoinColumn(name = "social_id", nullable = false)
 //  private Social social;
 
-	@Column(nullable = false)
+	@Column(length = 45, nullable = false)
 	private String title;
 
-	@Column(nullable = false)
+	@Column(length = 605, nullable = false)
 	private String content;
 
 	@CreatedDate

--- a/src/main/java/com/brick/demo/social/entity/QnaComment.java
+++ b/src/main/java/com/brick/demo/social/entity/QnaComment.java
@@ -26,36 +26,44 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class QnaComment {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-  @ManyToOne
-  @JoinColumn(name = "writer_id", nullable = false)
-  private Account writer;
+	@ManyToOne
+	@JoinColumn(name = "writer_id", nullable = false)
+	private Account writer;
 
-  @ManyToOne
-  @JoinColumn(name = "qna_id", nullable = false)
-  private Qna qna;
+	@ManyToOne
+	@JoinColumn(name = "qna_id", nullable = false)
+	private Qna qna;
 
-  @Column(nullable = false)
-  private String content;
+	@Column(length = 605, nullable = false)
+	private String content;
 
-  @CreatedDate
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private LocalDateTime createdAt;
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
 
-  @LastModifiedDate
-  @Column(name = "updated_at", nullable = false)
-  private LocalDateTime updatedAt;
+	@LastModifiedDate
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
 
-  @Column(name = "deleted_at")
-  private LocalDateTime deletedAt;
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
-  @Builder
-  public QnaComment(Account writer, Qna qna, String content) {
-    this.writer = writer;
-    this.qna = qna;
-    this.content = content;
-  }
+	@Builder
+	public QnaComment(Account writer, Qna qna, String content) {
+		this.writer = writer;
+		this.qna = qna;
+		this.content = content;
+	}
+
+	public void update(String content) {
+		this.content = content;
+	}
+
+	public void softDelete() {
+		this.deletedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/brick/demo/social/service/QnaCommentService.java
+++ b/src/main/java/com/brick/demo/social/service/QnaCommentService.java
@@ -1,0 +1,85 @@
+package com.brick.demo.social.service;
+
+import com.brick.demo.auth.entity.Account;
+import com.brick.demo.auth.repository.AccountManager;
+import com.brick.demo.common.CustomException;
+import com.brick.demo.common.ErrorDetails;
+import com.brick.demo.security.CustomUserDetails;
+import com.brick.demo.social.dto.QnaCommentPatchDto;
+import com.brick.demo.social.dto.QnaCommentRequestDto;
+import com.brick.demo.social.dto.QnaCommentResponseDto;
+import com.brick.demo.social.dto.QnaRequestDto;
+import com.brick.demo.social.dto.QnaResponseDto;
+import com.brick.demo.social.entity.Qna;
+import com.brick.demo.social.entity.QnaComment;
+import com.brick.demo.social.repository.QnaCommentRepository;
+import com.brick.demo.social.repository.QnaRepository;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class QnaCommentService {
+
+	private final QnaCommentRepository qnaCommentRepository;
+	private final AccountManager accountManager;
+	private final QnaRepository qnaRepository;
+
+	@Autowired
+	public QnaCommentService(QnaCommentRepository qnaCommentRepository,
+			AccountManager accountManager, QnaRepository qnaRepository) {
+		this.qnaCommentRepository = qnaCommentRepository;
+		this.accountManager = accountManager;
+		this.qnaRepository = qnaRepository;
+	}
+
+	@Transactional
+	public QnaCommentResponseDto create(Long qnaId, QnaCommentRequestDto dto) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+		final String writerName = userDetails.getName();
+		final Optional<Account> accountOptional = accountManager.getAccountByName(writerName);
+		if (accountOptional.isEmpty()) {
+			throw new CustomException(ErrorDetails.E001);
+		}
+		final Account account = accountOptional.get();
+		final Qna qna = qnaRepository.getOne(qnaId);
+		QnaComment qnaComment = dto.toEntity(qna, account);
+		qnaComment = qnaCommentRepository.save(qnaComment);
+
+		return new QnaCommentResponseDto(qnaComment);
+	}
+
+	@Transactional
+	public QnaCommentResponseDto update(Long commentId, QnaCommentPatchDto dto) {
+		QnaComment qnaComment = qnaCommentRepository.findById(commentId)
+				.orElseThrow(
+						() -> new CustomException(HttpStatus.NOT_FOUND, "해당하는 Qna 댓글 ID의 댓글을 찾을 수 없습니다"));
+
+		final String content = (dto.getContent() != null) ? dto.getContent() : qnaComment.getContent();
+		qnaComment.update(content);
+		qnaCommentRepository.save(qnaComment);
+		qnaCommentRepository.flush(); //영속성 컨텍스트의 변경사항을 DB에 바로 반영
+		LocalDateTime updatedAt = qnaCommentRepository.findById(commentId).get().getUpdatedAt();
+		return new QnaCommentResponseDto(qnaComment, updatedAt);
+	}
+
+	@Transactional
+	public void delete(Long commentId) {
+		QnaComment qnaComment = qnaCommentRepository.findById(commentId)
+				.orElseThrow(
+						() -> new CustomException(HttpStatus.NOT_FOUND, "해당하는 Qna 댓글 ID의 댓글을 찾을 수 없습니다"));
+		if (qnaComment.getDeletedAt() != null && qnaComment.getDeletedAt()
+				.isBefore(LocalDateTime.now())) {
+			throw new CustomException(HttpStatus.BAD_REQUEST, "이미 삭제된 Qna 댓글 입니다");
+		}
+		qnaComment.softDelete();
+		qnaCommentRepository.save(qnaComment);
+	}
+}


### PR DESCRIPTION
resolved #10 
## 작업 사항
- qna 댓글의 api를 작성했습니다.
-  POST `/socials/{id}/qnas/{qnaId}/comments`
-  PATCH `/socials/{id}/qnas/{qnaId}/comments/{commentId}`
-  DELETE `/socials/{id}/qnas/{qnaId}/comments/{commentId}`

## 고민한 점들(필수 X)
- 현재 댓글은 QNA 테이블만 참조하고 있습니다. 이후에 다른 포스트에서의 댓글이 생길까봐 타입을 넣을까 생각했는데, 아직 MVP 단계에서 추가될것이 없어 보이고, 그때는 그 포스트에 파생된 댓글 테이블을 만드는게 검색 시간이 더 효율적이라고 생각이 들었습니다. 