### PR TITLE
feat[#11]: social 도메인 구현하기 1차

### DIFF
--- a/src/main/java/com/brick/demo/DemoApplication.java
+++ b/src/main/java/com/brick/demo/DemoApplication.java
@@ -5,14 +5,15 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableJpaRepositories
 @Import(ApplicationConfig.class)
 public class DemoApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(DemoApplication.class, args);
   }
-
 }

--- a/src/main/java/com/brick/demo/common/ErrorDetails.java
+++ b/src/main/java/com/brick/demo/common/ErrorDetails.java
@@ -9,7 +9,10 @@ public enum ErrorDetails {
   E002("INVALID_CREDENTIALS", "잘못된 이메일 또는 비밀번호입니다", HttpStatus.UNAUTHORIZED),
   E003("UNAUTHORIZED", "Authorization 헤더가 필요합니다", HttpStatus.UNAUTHORIZED),
   E004("UNAUTHORIZED", "로그인한 상태에서 로그인 요청을 보낼 수 없습니다", HttpStatus.UNAUTHORIZED),
-  E005("UNAUTHORIZED", "로그아웃한 상태에서 로그아웃 요청을 보낼 수 없습니다", HttpStatus.UNAUTHORIZED);
+  E005("UNAUTHORIZED", "로그아웃한 상태에서 로그아웃 요청을 보낼 수 없습니다", HttpStatus.UNAUTHORIZED),
+
+  SOCIAL_NOT_FOUND("SOCIAL_NOT_FOUND", "아이디에 해당하는 모임을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+  SOCIAL_FORBIDDEN("SOCIAL_FORBIDDEN", "수정 권한이 없는 모임입니다.", HttpStatus.FORBIDDEN);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/brick/demo/common/entity/BaseEntity.java
+++ b/src/main/java/com/brick/demo/common/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.brick.demo.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+  @CreatedDate
+  @Column(name = "created_at", updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/brick/demo/config/ApplicationConfig.java
+++ b/src/main/java/com/brick/demo/config/ApplicationConfig.java
@@ -1,13 +1,11 @@
 package com.brick.demo.config;
 
-
 import com.brick.demo.auth.jwt.AccessToken;
 import com.brick.demo.auth.jwt.RefreshToken;
 import com.brick.demo.auth.repository.AccountManager;
 import com.brick.demo.auth.repository.AccountRepository;
 import com.brick.demo.auth.repository.InMemoryAccessTokenManager;
 import com.brick.demo.auth.repository.InMemoryRefreshTokenManager;
-import com.brick.demo.auth.repository.JpaAccountManager;
 import com.brick.demo.auth.repository.JpaRepositoryAccountManager;
 import com.brick.demo.auth.repository.TokenManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
-@EntityScan(basePackages = "com.brick.demo.auth.entity")
+@EntityScan(basePackages = "com.brick.demo")
 @EnableTransactionManagement
 public class ApplicationConfig {
 
@@ -31,14 +29,14 @@ public class ApplicationConfig {
   @Bean
   public AccountManager accountManager() {
     return new JpaRepositoryAccountManager(accountRepository);
-//    return new JpaAccountManager();
+    //    return new JpaAccountManager();
   }
 
   @Bean
   public TokenManager<AccessToken> accessTokenTokenManager() {
     return new InMemoryAccessTokenManager();
   }
-  
+
   @Bean
   public TokenManager<RefreshToken> refreshTokenManager() {
     return new InMemoryRefreshTokenManager();

--- a/src/main/java/com/brick/demo/social/controller/SocialController.java
+++ b/src/main/java/com/brick/demo/social/controller/SocialController.java
@@ -4,12 +4,12 @@ import com.brick.demo.social.dto.SocialCreateRequest;
 import com.brick.demo.social.dto.SocialCreateResponse;
 import com.brick.demo.social.dto.SocialResponse;
 import com.brick.demo.social.dto.SocialUpdateRequest;
-import com.brick.demo.social.entity.Social;
 import com.brick.demo.social.service.SocialService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,8 +26,9 @@ public class SocialController implements SocialControllerDocs {
   private final SocialService socialService;
 
   @GetMapping
-  public List<Social> findAll() {
-    return socialService.findAll();
+  public ResponseEntity<List<SocialResponse>> findAll() {
+    List<SocialResponse> response = socialService.findAll();
+    return ResponseEntity.ok(response);
   }
 
   @GetMapping("/{id}")
@@ -53,10 +54,9 @@ public class SocialController implements SocialControllerDocs {
     return ResponseEntity.ok("모임을 성공적으로 수정했습니다");
   }
 
-  // TODO 불필요한 경우 추후 삭제
-  //  @DeleteMapping("/{id}")
-  //  public ResponseEntity<Void> delete(@PathVariable final Long id) {
-  //    socialService.delete(id);
-  //    return null;
-  //  }
+  @DeleteMapping("/{id}")
+  public ResponseEntity<String> delete(@PathVariable final Long id) {
+    socialService.delete(id);
+    return ResponseEntity.ok("모임을 성공적으로 취소했습니다");
+  }
 }

--- a/src/main/java/com/brick/demo/social/controller/SocialController.java
+++ b/src/main/java/com/brick/demo/social/controller/SocialController.java
@@ -1,0 +1,62 @@
+package com.brick.demo.social.controller;
+
+import com.brick.demo.social.dto.SocialCreateRequest;
+import com.brick.demo.social.dto.SocialCreateResponse;
+import com.brick.demo.social.dto.SocialResponse;
+import com.brick.demo.social.dto.SocialUpdateRequest;
+import com.brick.demo.social.entity.Social;
+import com.brick.demo.social.service.SocialService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("social")
+@RequiredArgsConstructor
+public class SocialController implements SocialControllerDocs {
+
+  private final SocialService socialService;
+
+  @GetMapping
+  public List<Social> findAll() {
+    return socialService.findAll();
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<SocialResponse> findById(@PathVariable final Long id) {
+    SocialResponse response = socialService.findById(id);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping
+  public ResponseEntity<SocialCreateResponse> save(
+      @RequestBody @Valid final SocialCreateRequest dto) {
+    SocialCreateResponse response = socialService.save(dto);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<String> update(
+      @PathVariable final Long id, @RequestBody @Valid final SocialUpdateRequest dto) {
+    socialService.update(id, dto);
+
+    return ResponseEntity.ok("모임을 성공적으로 수정했습니다");
+  }
+
+  // TODO 불필요한 경우 추후 삭제
+  //  @DeleteMapping("/{id}")
+  //  public ResponseEntity<Void> delete(@PathVariable final Long id) {
+  //    socialService.delete(id);
+  //    return null;
+  //  }
+}

--- a/src/main/java/com/brick/demo/social/controller/SocialController.java
+++ b/src/main/java/com/brick/demo/social/controller/SocialController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,8 +27,9 @@ public class SocialController implements SocialControllerDocs {
   private final SocialService socialService;
 
   @GetMapping
-  public ResponseEntity<List<SocialResponse>> findAll() {
-    List<SocialResponse> response = socialService.findAll();
+  public ResponseEntity<List<SocialResponse>> findAll(
+      @RequestParam(required = false) final String orderBy) {
+    List<SocialResponse> response = socialService.findAll(orderBy);
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/com/brick/demo/social/controller/SocialControllerDocs.java
+++ b/src/main/java/com/brick/demo/social/controller/SocialControllerDocs.java
@@ -4,7 +4,6 @@ import com.brick.demo.social.dto.SocialCreateRequest;
 import com.brick.demo.social.dto.SocialCreateResponse;
 import com.brick.demo.social.dto.SocialResponse;
 import com.brick.demo.social.dto.SocialUpdateRequest;
-import com.brick.demo.social.entity.Social;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -16,13 +15,15 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface SocialControllerDocs {
 
   @Operation(summary = "모임 전체 조회", description = "전체 모임을 조회합니다.")
   @ApiResponse(responseCode = "200", description = "조회 성공")
   @GetMapping
-  List<Social> findAll();
+  ResponseEntity<List<SocialResponse>> findAll(
+      @RequestParam(required = false) final String orderBy);
 
   @Operation(summary = "특정 모임 조회", description = "해당 아이디의 모임을 조회합니다.")
   @ApiResponses({
@@ -37,7 +38,7 @@ public interface SocialControllerDocs {
   @PostMapping
   ResponseEntity<SocialCreateResponse> save(@Valid final SocialCreateRequest dto);
 
-  @Operation(summary = "모임 수정", description = "모임을 수정합니다.")
+  @Operation(summary = "특정 모임 수정", description = "해당 아이디의 모임을 수정합니다.")
   @ApiResponses({
     @ApiResponse(responseCode = "200", description = "수정 성공"),
     @ApiResponse(responseCode = "403", description = "수정 실패 - 주최자 권한이 없음"),
@@ -47,13 +48,37 @@ public interface SocialControllerDocs {
   ResponseEntity<String> update(
       @PathVariable Long id, @RequestBody @Valid final SocialUpdateRequest dto);
 
-  // TODO 불필요한 경우 추후 삭제
-  //  @Operation(summary = "모임 삭제", description = "모임을 삭제합니다.")
+  //  @Operation(summary = "특정 모임 취소", description = "해당 아이디의 모임을 취소합니다.")
   //  @ApiResponses({
-  //    @ApiResponse(responseCode = "200", description = "삭제 성공"),
-  //    @ApiResponse(responseCode = "403", description = "삭제 실패 - 주최자 권한이 없음"),
-  //    @ApiResponse(responseCode = "404", description = "삭제 실패 - 존재하지 않는 모임 아이디")
+  //    @ApiResponse(responseCode = "200", description = "취소 성공"),
+  //    @ApiResponse(responseCode = "403", description = "취소 실패 - 주최자 권한이 없음"),
+  //    @ApiResponse(responseCode = "404", description = "취소 실패 - 존재하지 않는 모임 아이디")
   //  })
   //  @DeleteMapping("/{id}")
-  //  ResponseEntity<Void> delete(@PathVariable final Long id);
+  //  ResponseEntity<String> delete(@PathVariable final Long id);
+  //
+  //  @Operation(summary = "모임 상세 정보 조회", description = "모임의 상세 정보를 조회합니다.")
+  //  @ApiResponse(responseCode = "200", description = "조회 성공")
+  //  @GetMapping("/{id}/details")
+  //  ResponseEntity<SocialDetailResponse> findDetailBySocialId(@PathVariable final Long id);
+  //
+  //  @Operation(summary = "특정 모임 참여", description = "해당 아이디의 모임에 참여합니다.")
+  //  @ApiResponses({
+  //    @ApiResponse(responseCode = "200", description = "참여 성공"),
+  //    @ApiResponse(responseCode = "400", description = "참여 실패 - 이미 참여한 모임이거나 더 이상 인원을 수용할 수 없음"),
+  //    @ApiResponse(responseCode = "401", description = "참여 실패 - 로그인하지 않은 사용자"),
+  //    @ApiResponse(responseCode = "404", description = "참여 실패 - 존재하지 않는 모임 아이디")
+  //  })
+  //  @PostMapping("/{id}/participants")
+  //  ResponseEntity<String> saveParticipant(@PathVariable final Long id);
+  //
+  //  @Operation(summary = "특정 모임 참여 취소", description = "해당 아이디의 모임에 참여를 취소합니다.")
+  //  @ApiResponses({
+  //    @ApiResponse(responseCode = "200", description = "취소 성공"),
+  //    @ApiResponse(responseCode = "400", description = "취소 실패 - 이미 지났거나 참여하지 않은 모임"),
+  //    @ApiResponse(responseCode = "401", description = "취소 실패 - 로그인하지 않은 사용자"),
+  //    @ApiResponse(responseCode = "404", description = "취소 실패 - 존재하지 않는 모임 아이디")
+  //  })
+  //  @DeleteMapping("/{id}/participants")
+  //  ResponseEntity<String> deleteParticipant(@PathVariable final Long id);
 }

--- a/src/main/java/com/brick/demo/social/controller/SocialControllerDocs.java
+++ b/src/main/java/com/brick/demo/social/controller/SocialControllerDocs.java
@@ -1,0 +1,59 @@
+package com.brick.demo.social.controller;
+
+import com.brick.demo.social.dto.SocialCreateRequest;
+import com.brick.demo.social.dto.SocialCreateResponse;
+import com.brick.demo.social.dto.SocialResponse;
+import com.brick.demo.social.dto.SocialUpdateRequest;
+import com.brick.demo.social.entity.Social;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface SocialControllerDocs {
+
+  @Operation(summary = "모임 전체 조회", description = "전체 모임을 조회합니다.")
+  @ApiResponse(responseCode = "200", description = "조회 성공")
+  @GetMapping
+  List<Social> findAll();
+
+  @Operation(summary = "특정 모임 조회", description = "해당 아이디의 모임을 조회합니다.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "조회 성공"),
+    @ApiResponse(responseCode = "404", description = "조회 실패 - 존재하지 않는 모임 아이디")
+  })
+  @GetMapping("/{id}")
+  ResponseEntity<SocialResponse> findById(@PathVariable final Long id);
+
+  @Operation(summary = "모임 생성", description = "모임을 생성합니다.")
+  @ApiResponse(responseCode = "200", description = "모임 생성 성공")
+  @PostMapping
+  ResponseEntity<SocialCreateResponse> save(@Valid final SocialCreateRequest dto);
+
+  @Operation(summary = "모임 수정", description = "모임을 수정합니다.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "수정 성공"),
+    @ApiResponse(responseCode = "403", description = "수정 실패 - 주최자 권한이 없음"),
+    @ApiResponse(responseCode = "404", description = "수정 실패 - 존재하지 않는 모임 아이디")
+  })
+  @PatchMapping("/{id}")
+  ResponseEntity<String> update(
+      @PathVariable Long id, @RequestBody @Valid final SocialUpdateRequest dto);
+
+  // TODO 불필요한 경우 추후 삭제
+  //  @Operation(summary = "모임 삭제", description = "모임을 삭제합니다.")
+  //  @ApiResponses({
+  //    @ApiResponse(responseCode = "200", description = "삭제 성공"),
+  //    @ApiResponse(responseCode = "403", description = "삭제 실패 - 주최자 권한이 없음"),
+  //    @ApiResponse(responseCode = "404", description = "삭제 실패 - 존재하지 않는 모임 아이디")
+  //  })
+  //  @DeleteMapping("/{id}")
+  //  ResponseEntity<Void> delete(@PathVariable final Long id);
+}

--- a/src/main/java/com/brick/demo/social/dto/JoinedSocialResponse.java
+++ b/src/main/java/com/brick/demo/social/dto/JoinedSocialResponse.java
@@ -1,0 +1,41 @@
+package com.brick.demo.social.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record JoinedSocialResponse(
+    @Schema(description = "모임 아이디", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull Long id,
+
+    @Schema(description = "모임 이름", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String name,
+
+    @Schema(description = "모임 일정", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty LocalDateTime gatheringDate,
+
+    @Schema(description = "가입 일시", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty LocalDateTime joinedAt,
+
+    @Schema(description = "장소", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String address,
+
+    @Schema(description = "모임 정원", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Valid ParticipantCount participantCount,
+
+    @Schema(description = "썸네일 URL")
+    String thumbnail,
+
+    @Schema(description = "태그", requiredMode = Schema.RequiredMode.REQUIRED)
+    String[] tags,
+
+    @Schema(description = "주최자", requiredMode = RequiredMode.REQUIRED)
+    @Valid Participant owner,
+
+    @Schema(description = "참여자", requiredMode = RequiredMode.REQUIRED)
+    @Valid Participant[] participants
+) {
+}

--- a/src/main/java/com/brick/demo/social/dto/Participant.java
+++ b/src/main/java/com/brick/demo/social/dto/Participant.java
@@ -1,0 +1,16 @@
+package com.brick.demo.social.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+public record Participant(
+    @Schema(description = "모임 참가자의 이름", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty  String name,
+
+    @Schema(description = "모임 참가자의 프로필")
+    String profileUrl,
+
+    @Schema(description = "모임 참가자의 역할")
+    String role
+) {
+}

--- a/src/main/java/com/brick/demo/social/dto/ParticipantCount.java
+++ b/src/main/java/com/brick/demo/social/dto/ParticipantCount.java
@@ -1,0 +1,17 @@
+package com.brick.demo.social.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.validation.constraints.NotNull;
+
+public record ParticipantCount(
+    @Schema(description = "최소 인원 수", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull Integer min,
+
+    @Schema(description = "최대 인원 수", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull Integer max,
+
+    @Schema(description = "현재 인원 수", requiredMode = RequiredMode.NOT_REQUIRED)
+    Integer current
+) {
+}

--- a/src/main/java/com/brick/demo/social/dto/Place.java
+++ b/src/main/java/com/brick/demo/social/dto/Place.java
@@ -1,0 +1,20 @@
+package com.brick.demo.social.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record Place(
+    @Schema(description = "주소", example = "서울시 강남구 테헤란로 123", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String address,
+
+    @Schema(description = "상세 주소", example = "456동 789호", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String detailAddress,
+
+    @Schema(description = "모임이 열리는 장소의 위도", example = "37.5665", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull Double latitude,
+
+    @Schema(description = "모임이 열리는 장소의 경도", example = "126.978", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull Double longitude
+) {
+}

--- a/src/main/java/com/brick/demo/social/dto/SocialCreateRequest.java
+++ b/src/main/java/com/brick/demo/social/dto/SocialCreateRequest.java
@@ -1,0 +1,34 @@
+package com.brick.demo.social.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import java.time.LocalDateTime;
+
+public record SocialCreateRequest (
+    @Schema(description = "모임 이름", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String name,
+
+    @Schema(description = "모임 소개", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String description,
+
+    @Schema(description = "모임 일정", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty LocalDateTime gatheringDate,
+
+    @Schema(description = "모임 정원", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Valid ParticipantCount participantCount,
+
+    @Schema(description = "장소 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Valid Place place,
+
+    @Schema(description = "이미지 URL 배열")
+    String[] imageUrls,
+
+    @Schema(description = "활동비", requiredMode = RequiredMode.NOT_REQUIRED)
+    Integer dues,
+
+    @Schema(description = "태그", requiredMode = Schema.RequiredMode.REQUIRED)
+    String[] tags
+    ) {
+}

--- a/src/main/java/com/brick/demo/social/dto/SocialCreateResponse.java
+++ b/src/main/java/com/brick/demo/social/dto/SocialCreateResponse.java
@@ -1,0 +1,16 @@
+package com.brick.demo.social.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record SocialCreateResponse(
+    @Schema(description = "모임 아이디", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull Long id,
+
+    @Schema(description = "모임 생성 성공 메시지", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String message
+) {
+}

--- a/src/main/java/com/brick/demo/social/dto/SocialDetailIntroductionResponse.java
+++ b/src/main/java/com/brick/demo/social/dto/SocialDetailIntroductionResponse.java
@@ -1,0 +1,18 @@
+package com.brick.demo.social.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
+public record SocialDetailIntroductionResponse (
+    @Schema(description = "모임 소개", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String description,
+
+    @Schema(description = "장소 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Valid Place place,
+
+    @Schema(description = "참여자", requiredMode = RequiredMode.REQUIRED)
+    @Valid Participant[] participants
+) {
+}

--- a/src/main/java/com/brick/demo/social/dto/SocialDetailResponse.java
+++ b/src/main/java/com/brick/demo/social/dto/SocialDetailResponse.java
@@ -1,0 +1,41 @@
+package com.brick.demo.social.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record SocialDetailResponse(
+    @Schema(description = "모임 아이디", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull Long id,
+
+    @Schema(description = "모임 이름", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String name,
+
+    @Schema(description = "모임 소개", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String description,
+
+    @Schema(description = "모임 일정", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty LocalDateTime gatheringDate,
+
+    @Schema(description = "모임 정원", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Valid ParticipantCount participantCount,
+
+    @Schema(description = "이미지 URL 배열")
+    String[] imageUrls,
+
+    @Schema(description = "활동비", requiredMode = RequiredMode.NOT_REQUIRED)
+    Integer dues,
+
+    @Schema(description = "태그", requiredMode = Schema.RequiredMode.REQUIRED)
+    String[] tags,
+
+    @Schema(description = "주최자", requiredMode = RequiredMode.REQUIRED)
+    @Valid Participant owner,
+
+    @Schema(description = "참여자", requiredMode = RequiredMode.REQUIRED)
+    @Valid Participant[] participants
+) {
+}

--- a/src/main/java/com/brick/demo/social/dto/SocialResponse.java
+++ b/src/main/java/com/brick/demo/social/dto/SocialResponse.java
@@ -1,6 +1,7 @@
 package com.brick.demo.social.dto;
 
 import com.brick.demo.social.entity.Social;
+import com.brick.demo.social.enums.ParticipantRole;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
@@ -39,7 +40,10 @@ public record SocialResponse(
                 social.getMinCount(), social.getMaxCount(), social.getParticipants().size());
 
         // TODO 추후 role enum 관리
-        Participant owner = new Participant(social.getOwner().getName(), "TODO 프로필 URL", "role");
+        Participant owner = new Participant(
+            social.getOwner().getName(),
+            "TODO 프로필 URL",
+            ParticipantRole.OWNER.name());
 
         return new SocialResponse(
             social.getId(),

--- a/src/main/java/com/brick/demo/social/dto/SocialResponse.java
+++ b/src/main/java/com/brick/demo/social/dto/SocialResponse.java
@@ -1,0 +1,55 @@
+package com.brick.demo.social.dto;
+
+import com.brick.demo.social.entity.Social;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record SocialResponse(
+    @Schema(description = "모임 아이디", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull Long id,
+
+    @Schema(description = "모임 이름", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String name,
+
+    @Schema(description = "모임 일정", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty LocalDateTime gatheringDate,
+
+    @Schema(description = "장소", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String address,
+
+    @Schema(description = "모임 정원", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Valid ParticipantCount participantCount,
+
+    @Schema(description = "썸네일 URL")
+    String thumbnail,
+
+    @Schema(description = "태그", requiredMode = Schema.RequiredMode.REQUIRED)
+    String[] tags,
+
+    @Schema(description = "주최자", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Valid Participant owner
+) {
+
+    public static SocialResponse fromEntity(Social social) {
+        ParticipantCount participantCount =
+            new ParticipantCount(
+                social.getMinCount(), social.getMaxCount(), social.getParticipants().size());
+
+        // TODO 추후 role enum 관리
+        Participant owner = new Participant(social.getOwner().getName(), "TODO 프로필 URL", "role");
+
+        return new SocialResponse(
+            social.getId(),
+            social.getName(),
+            social.getGatheringDate(),
+            social.getAddress(),
+            participantCount,
+            social.getImageUrls(),
+            social.getTags().split(","),
+            owner
+        );
+    }
+}

--- a/src/main/java/com/brick/demo/social/dto/SocialUpdateRequest.java
+++ b/src/main/java/com/brick/demo/social/dto/SocialUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.brick.demo.social.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
+public record SocialUpdateRequest(
+    @Schema(description = "모임 이름", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String name,
+
+    @Schema(description = "모임 소개", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty String description,
+
+    @Schema(description = "장소 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Valid Place place,
+
+    @Schema(description = "이미지 URL 배열")
+    String[] imageUrls
+) {
+}

--- a/src/main/java/com/brick/demo/social/entity/Social.java
+++ b/src/main/java/com/brick/demo/social/entity/Social.java
@@ -1,0 +1,73 @@
+package com.brick.demo.social.entity;
+
+import com.brick.demo.auth.entity.Account;
+import com.brick.demo.common.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "social")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class Social extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  private Long id;
+
+  @Column(name = "name", nullable = false, length = 20)
+  private String name;
+
+  @Column(name = "gathering_date", nullable = false)
+  private LocalDateTime gatheringDate;
+
+  @Column(name = "address")
+  private String address;
+
+  @Column(name = "image_urls")
+  private String imageUrls;
+
+  @Column(name = "tags")
+  private String tags;
+
+  @Column(name = "min_count", nullable = false)
+  private Integer minCount;
+
+  @Column(name = "max_count", nullable = false)
+  private Integer maxCount;
+
+  @Column(name = "dues", nullable = false)
+  private Integer dues = 0;
+
+  @OneToOne(
+      mappedBy = "social",
+      cascade = CascadeType.ALL,
+      fetch = FetchType.LAZY,
+      optional = false)
+  private SocialDetail socialDetail;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "account_id", nullable = false)
+  private Account owner;
+
+  @OneToMany(mappedBy = "social", cascade = CascadeType.ALL, orphanRemoval = true)
+  private Set<SocialParticipant> participants;
+}

--- a/src/main/java/com/brick/demo/social/entity/Social.java
+++ b/src/main/java/com/brick/demo/social/entity/Social.java
@@ -23,6 +23,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "social")
@@ -43,9 +44,11 @@ public class Social extends BaseEntity {
   private LocalDateTime gatheringDate;
 
   @Column(name = "address")
+  @Setter
   private String address;
 
   @Column(name = "image_urls")
+  @Setter
   private String imageUrls;
 
   @Column(name = "tags")
@@ -60,12 +63,17 @@ public class Social extends BaseEntity {
   @Column(name = "dues", nullable = false)
   private Integer dues = 0;
 
+  @Column(name = "canceled")
+  @Setter
+  private Boolean canceled;
+
   @OneToOne(
       mappedBy = "social",
       cascade = CascadeType.ALL,
       fetch = FetchType.LAZY,
       optional = false)
-  private SocialDetail socialDetail;
+  @Setter
+  private SocialDetail detail;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
@@ -112,38 +120,19 @@ public class Social extends BaseEntity {
         account);
   }
 
-  public static Social update(final Social social, final SocialUpdateRequest dto) {
-    String address = dto.place().address() + ' ' + dto.place().detailAddress();
-    String imageUrls = String.join(",", dto.imageUrls());
-
-    return new Social(
-        social.getId(),
-        dto.name(),
-        social.getGatheringDate(),
-        address,
-        imageUrls,
-        social.getTags(),
-        social.getMinCount(),
-        social.getMaxCount(),
-        social.getDues(),
-        social.getSocialDetail(),
-        social.getOwner(),
-        social.getParticipants());
+  public static Social update(Social social, final SocialUpdateRequest dto) {
+    social.address = dto.place().address() + ' ' + dto.place().detailAddress();
+    social.imageUrls = String.join(",", dto.imageUrls());
+    return social;
   }
 
-  public static Social updateDetail(final Social social, final SocialDetail detail) {
-    return new Social(
-        social.getId(),
-        social.getName(),
-        social.getGatheringDate(),
-        social.getAddress(),
-        social.getImageUrls(),
-        social.getTags(),
-        social.getMinCount(),
-        social.getMaxCount(),
-        social.getDues(),
-        detail,
-        social.getOwner(),
-        social.getParticipants());
+  public static Social cancel(Social social) {
+    social.canceled = true;
+    return social;
+  }
+
+  public static Social updateDetail(Social social, final SocialDetail detail) {
+    social.detail = detail;
+    return social;
   }
 }

--- a/src/main/java/com/brick/demo/social/entity/Social.java
+++ b/src/main/java/com/brick/demo/social/entity/Social.java
@@ -2,6 +2,8 @@ package com.brick.demo.social.entity;
 
 import com.brick.demo.auth.entity.Account;
 import com.brick.demo.common.entity.BaseEntity;
+import com.brick.demo.social.dto.SocialCreateRequest;
+import com.brick.demo.social.dto.SocialUpdateRequest;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,17 +17,18 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.Set;
 import lombok.AccessLevel;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "social")
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Builder
 public class Social extends BaseEntity {
 
   @Id
@@ -69,5 +72,78 @@ public class Social extends BaseEntity {
   private Account owner;
 
   @OneToMany(mappedBy = "social", cascade = CascadeType.ALL, orphanRemoval = true)
-  private Set<SocialParticipant> participants;
+  private Set<SocialParticipant> participants = new HashSet<>();
+
+  public Social(
+      String name,
+      LocalDateTime gatheringDate,
+      String address,
+      String imageUrls,
+      String tags,
+      Integer min,
+      Integer max,
+      Integer dues,
+      Account account) {
+    this.name = name;
+    this.gatheringDate = gatheringDate;
+    this.address = address;
+    this.imageUrls = imageUrls;
+    this.tags = tags;
+    this.minCount = min;
+    this.maxCount = max;
+    this.dues = dues;
+    this.owner = account;
+  }
+
+  public static Social save(final Account account, final SocialCreateRequest dto) {
+    String address = dto.place().address() + ' ' + dto.place().detailAddress();
+    String imageUrls = String.join(",", dto.imageUrls());
+    String tags = String.join(",", dto.tags());
+
+    return new Social(
+        dto.name(),
+        dto.gatheringDate(),
+        address,
+        imageUrls,
+        tags,
+        dto.participantCount().min(),
+        dto.participantCount().max(),
+        dto.dues(),
+        account);
+  }
+
+  public static Social update(final Social social, final SocialUpdateRequest dto) {
+    String address = dto.place().address() + ' ' + dto.place().detailAddress();
+    String imageUrls = String.join(",", dto.imageUrls());
+
+    return new Social(
+        social.getId(),
+        dto.name(),
+        social.getGatheringDate(),
+        address,
+        imageUrls,
+        social.getTags(),
+        social.getMinCount(),
+        social.getMaxCount(),
+        social.getDues(),
+        social.getSocialDetail(),
+        social.getOwner(),
+        social.getParticipants());
+  }
+
+  public static Social updateDetail(final Social social, final SocialDetail detail) {
+    return new Social(
+        social.getId(),
+        social.getName(),
+        social.getGatheringDate(),
+        social.getAddress(),
+        social.getImageUrls(),
+        social.getTags(),
+        social.getMinCount(),
+        social.getMaxCount(),
+        social.getDues(),
+        detail,
+        social.getOwner(),
+        social.getParticipants());
+  }
 }

--- a/src/main/java/com/brick/demo/social/entity/SocialDetail.java
+++ b/src/main/java/com/brick/demo/social/entity/SocialDetail.java
@@ -1,0 +1,41 @@
+package com.brick.demo.social.entity;
+
+import com.brick.demo.common.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "social_detail")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+public class SocialDetail extends BaseEntity {
+
+  @Id
+  @Column(name = "id")
+  private Long id;
+
+  @MapsId
+  @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @JoinColumn(name = "social_id")
+  private Social social;
+
+  @Column(name = "description", nullable = false, length = 3000)
+  private String description;
+
+  @Column(name = "geo_location")
+  private String geoLocation;
+}

--- a/src/main/java/com/brick/demo/social/entity/SocialDetail.java
+++ b/src/main/java/com/brick/demo/social/entity/SocialDetail.java
@@ -1,6 +1,7 @@
 package com.brick.demo.social.entity;
 
 import com.brick.demo.common.entity.BaseEntity;
+import com.brick.demo.social.dto.SocialCreateRequest;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,16 +13,14 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "social_detail")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Builder
 public class SocialDetail extends BaseEntity {
 
   @Id
@@ -38,4 +37,16 @@ public class SocialDetail extends BaseEntity {
 
   @Column(name = "geo_location")
   private String geoLocation;
+
+  public SocialDetail(final Social social, final String description, final String geoLocation) {
+    super();
+    this.social = social;
+    this.description = description;
+    this.geoLocation = geoLocation;
+  }
+
+  public static SocialDetail save(final Social social, final SocialCreateRequest dto) {
+    String geoLocation = dto.place().latitude() + " " + dto.place().longitude();
+    return new SocialDetail(social, dto.description(), geoLocation);
+  }
 }

--- a/src/main/java/com/brick/demo/social/entity/SocialParticipant.java
+++ b/src/main/java/com/brick/demo/social/entity/SocialParticipant.java
@@ -1,0 +1,40 @@
+package com.brick.demo.social.entity;
+
+import com.brick.demo.auth.entity.Account;
+import com.brick.demo.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "social_participant")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+public class SocialParticipant extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "social_id", nullable = false)
+  private Social social;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "account_id", nullable = false)
+  private Account account;
+}

--- a/src/main/java/com/brick/demo/social/entity/SocialParticipant.java
+++ b/src/main/java/com/brick/demo/social/entity/SocialParticipant.java
@@ -13,16 +13,14 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "social_participant")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Builder
 public class SocialParticipant extends BaseEntity {
 
   @Id
@@ -37,4 +35,9 @@ public class SocialParticipant extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;
+
+  public SocialParticipant(final Social social, final Account account) {
+    this.social = social;
+    this.account = account;
+  }
 }

--- a/src/main/java/com/brick/demo/social/enums/ParticipantRole.java
+++ b/src/main/java/com/brick/demo/social/enums/ParticipantRole.java
@@ -1,0 +1,12 @@
+package com.brick.demo.social.enums;
+
+public enum ParticipantRole {
+  OWNER("owner"),
+  PARTICIPANT("participant");
+
+  private final String name;
+
+  ParticipantRole(String name) {
+    this.name = name;
+  }
+}

--- a/src/main/java/com/brick/demo/social/repository/SocialDetailRepository.java
+++ b/src/main/java/com/brick/demo/social/repository/SocialDetailRepository.java
@@ -1,0 +1,8 @@
+package com.brick.demo.social.repository;
+
+import com.brick.demo.social.entity.SocialDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SocialDetailRepository extends JpaRepository<SocialDetail, Long> {}

--- a/src/main/java/com/brick/demo/social/repository/SocialRepository.java
+++ b/src/main/java/com/brick/demo/social/repository/SocialRepository.java
@@ -1,0 +1,24 @@
+package com.brick.demo.social.repository;
+
+import com.brick.demo.social.entity.Social;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SocialRepository extends JpaRepository<Social, Long> {
+  @Query("SELECT s FROM Social s WHERE s.gatheringDate > :date")
+  List<Social> findAllByGatheringDateAfter(@Param("date") LocalDateTime date);
+
+  @Query("SELECT s FROM Social s WHERE s.gatheringDate <= :date")
+  List<Social> findAllByGatheringDateBefore(@Param("date") LocalDateTime date);
+
+  @Query("SELECT s FROM Social s ORDER BY s.gatheringDate DESC")
+  List<Social> findAllOrderByGatheringDateDesc();
+
+  @Query("SELECT s FROM Social s LEFT JOIN s.participants p GROUP BY s ORDER BY COUNT(p) DESC")
+  List<Social> findAllOrderByPopularity();
+}

--- a/src/main/java/com/brick/demo/social/service/SocialService.java
+++ b/src/main/java/com/brick/demo/social/service/SocialService.java
@@ -1,0 +1,86 @@
+package com.brick.demo.social.service;
+
+import com.brick.demo.auth.entity.Account;
+import com.brick.demo.auth.repository.AccountManager;
+import com.brick.demo.common.CustomException;
+import com.brick.demo.common.ErrorDetails;
+import com.brick.demo.security.CustomUserDetails;
+import com.brick.demo.social.dto.SocialCreateRequest;
+import com.brick.demo.social.dto.SocialCreateResponse;
+import com.brick.demo.social.dto.SocialResponse;
+import com.brick.demo.social.dto.SocialUpdateRequest;
+import com.brick.demo.social.entity.Social;
+import com.brick.demo.social.entity.SocialDetail;
+import com.brick.demo.social.repository.SocialDetailRepository;
+import com.brick.demo.social.repository.SocialRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SocialService {
+
+  private final SocialRepository socialRepository;
+  private final SocialDetailRepository socialDetailRepository;
+  private final AccountManager accountManager;
+
+  // TODO 필터링 추가 + DTO 수정 필요
+  public List<Social> findAll() {
+    return socialRepository.findAll();
+  }
+
+  public SocialResponse findById(Long id) throws CustomException {
+    Social social =
+        socialRepository
+            .findById(id)
+            .orElseThrow(() -> new CustomException(ErrorDetails.SOCIAL_NOT_FOUND));
+
+    return SocialResponse.fromEntity(social);
+  }
+
+  public SocialCreateResponse save(final SocialCreateRequest dto) {
+    Account account = getAccount();
+    Social social = socialRepository.save(Social.save(account, dto));
+    SocialDetail detail = socialDetailRepository.save(SocialDetail.save(social, dto));
+    // TODO 참가자 업데이트
+    socialRepository.save(Social.updateDetail(social, detail));
+
+    return new SocialCreateResponse(social.getId(), "모임을 성공적으로 생성하였습니다.");
+  }
+
+  public void update(final Long id, final SocialUpdateRequest dto) {
+    Account account = getAccount();
+    Social social =
+        socialRepository
+            .findById(id)
+            .orElseThrow(() -> new CustomException(ErrorDetails.SOCIAL_NOT_FOUND));
+    if (account.getName() != social.getOwner().getName()) {
+      throw new CustomException(ErrorDetails.SOCIAL_NOT_FOUND);
+    }
+    socialRepository.save(Social.update(social, dto));
+  }
+
+  public void delete(Long id) {
+    Account account = getAccount();
+    Social social =
+        socialRepository
+            .findById(id)
+            .orElseThrow(() -> new CustomException(ErrorDetails.SOCIAL_NOT_FOUND));
+    if (account.getName() != social.getOwner().getName()) {
+      throw new CustomException(ErrorDetails.SOCIAL_NOT_FOUND);
+    }
+    socialRepository.deleteById(id);
+  }
+
+  private Account getAccount() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();
+    String name = userDetails.getName();
+    return accountManager.getAccountByName(name).get();
+  }
+}

--- a/src/main/java/com/brick/demo/social/service/SocialService.java
+++ b/src/main/java/com/brick/demo/social/service/SocialService.java
@@ -14,6 +14,7 @@ import com.brick.demo.social.entity.SocialDetail;
 import com.brick.demo.social.repository.SocialDetailRepository;
 import com.brick.demo.social.repository.SocialRepository;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -29,9 +30,10 @@ public class SocialService {
   private final SocialDetailRepository socialDetailRepository;
   private final AccountManager accountManager;
 
-  // TODO 필터링 추가 + DTO 수정 필요
-  public List<Social> findAll() {
-    return socialRepository.findAll();
+  // TODO 필터링 추가
+  public List<SocialResponse> findAll() {
+    List<Social> socials = socialRepository.findAll();
+    return socials.stream().map(SocialResponse::fromEntity).collect(Collectors.toList());
   }
 
   public SocialResponse findById(Long id) throws CustomException {


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

resolved #11 

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
소셜 도메인 1차 구현

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 소셜과 관련된 entity 및 dto 구현
- 기본적인 crud 1차 구현 (정상동작 확인 필요)

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

소셜과 관련된 도메인을 크게 세 부분으로 나눠봤습니다...!
- `social` : 목록 조회 시 뿌려지는 필드 정의
- `social_detail` : 상세 정보 조회 시 뿌려지는 필드 정의
- `social_participants` : 소셜 참가자

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
