### PR TITLE
fix[#15]: Account entity 수정. 회원 수정/탈퇴 구현

### DIFF
--- a/src/main/java/com/brick/demo/auth/controller/AuthController.java
+++ b/src/main/java/com/brick/demo/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.brick.demo.auth.dto.DuplicateNameResponseDto;
 import com.brick.demo.auth.dto.SignUpRequestDto;
 import com.brick.demo.auth.dto.SigninRequestDto;
 import com.brick.demo.auth.dto.SigninResponseDto;
+import com.brick.demo.auth.dto.UserPatchRequestDto;
 import com.brick.demo.auth.dto.UserResponseDto;
 import com.brick.demo.auth.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,7 +20,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -32,54 +36,66 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 public class AuthController {
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-  private final AuthService authService;
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+	private final AuthService authService;
 
 
-  @Autowired
-  public AuthController(AuthService authService) {
-    this.authService = authService;
-  }
+	@Autowired
+	public AuthController(AuthService authService) {
+		this.authService = authService;
+	}
 
-  @GetMapping(value = "/user")
-  public Optional<UserResponseDto> accountDetails() {
-    return authService.getAccountDetail();
-  }
+	@GetMapping(value = "/users")
+	public Optional<UserResponseDto> accountDetails() {
+		return authService.getAccountDetail();
+	}
 
-  @PostMapping("/signup")
-  @ResponseStatus(HttpStatus.CREATED)
-  public void createAccount(@Valid @RequestBody SignUpRequestDto dto) {
-    authService.createAccount(dto);
-  }
+	@PatchMapping(value = "/users")
+	public UserResponseDto updateAccount(@RequestBody UserPatchRequestDto dto) {
+		return authService.updateAccount(dto);
+	}
 
-  @PostMapping("/signin")
-  public SigninResponseDto createAuthenticationToken(
-      @RequestBody SigninRequestDto dto) {
-    return authService.signin(dto);
-  }
+	@DeleteMapping("/users")
+	public ResponseEntity<Void> delete(HttpServletRequest request, HttpServletResponse response) {
+		authService.deleteAccount(request, response);
+		return ResponseEntity.noContent().build();
+	}
 
-  @GetMapping("/signout")
-  public ResponseEntity<Void> signout(
-      HttpServletRequest request, HttpServletResponse response) {
-    return authService.signout(request, response);
-  }
+
+	@PostMapping("/signup")
+	@ResponseStatus(HttpStatus.CREATED)
+	public void createAccount(@Valid @RequestBody SignUpRequestDto dto) {
+		authService.createAccount(dto);
+	}
+
+	@PostMapping("/signin")
+	public SigninResponseDto createAuthenticationToken(
+			@RequestBody SigninRequestDto dto) {
+		return authService.signin(dto);
+	}
+
+	@GetMapping("/signout")
+	public ResponseEntity<Void> signout(
+			HttpServletRequest request, HttpServletResponse response) {
+		return authService.signout(request, response);
+	}
 
 //  @PostMapping("/reissue")
 //  public ResponseEntity<TokenDto> reissue(@RequestBody TokenRequestDto tokenRequestDto) {
 //    return ResponseEntity.ok(authService.reissue(tokenRequestDto));
 //  }
 
-  @PostMapping("/users/duplicate-email")
-  public DuplicateEmailResponseDto duplicateEmail(
-      @RequestBody DuplicateEmailRequestDto dto) {
-    return authService.isDuplicatedEmail(dto);
-  }
+	@PostMapping("/users/duplicate-email")
+	public DuplicateEmailResponseDto duplicateEmail(
+			@RequestBody DuplicateEmailRequestDto dto) {
+		return authService.isDuplicatedEmail(dto);
+	}
 
 
-  @PostMapping("/users/duplicate-name")
-  public DuplicateNameResponseDto duplicateName(
-      @RequestBody DuplicateNameRequestDto dto) {
-    return authService.isDuplicatedName(dto);
-  }
+	@PostMapping("/users/duplicate-name")
+	public DuplicateNameResponseDto duplicateName(
+			@RequestBody DuplicateNameRequestDto dto) {
+		return authService.isDuplicatedName(dto);
+	}
 }
 

--- a/src/main/java/com/brick/demo/auth/dto/UserPatchRequestDto.java
+++ b/src/main/java/com/brick/demo/auth/dto/UserPatchRequestDto.java
@@ -1,0 +1,13 @@
+package com.brick.demo.auth.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class UserPatchRequestDto {
+
+	private LocalDate birthday;
+	private String introduce;
+	private String profileImageUrl;
+
+}

--- a/src/main/java/com/brick/demo/auth/dto/UserResponseDto.java
+++ b/src/main/java/com/brick/demo/auth/dto/UserResponseDto.java
@@ -1,17 +1,28 @@
 package com.brick.demo.auth.dto;
 
+import com.brick.demo.auth.entity.Account;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.time.LocalDate;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class UserResponseDto {
 
-  private String email;
-  private String name;
+	private final String email;
+	private final String name;
+	private final LocalDate birthday;
+	private final String introduce;
+	private final String profileImageUrl;
 
-  @JsonCreator
-  public UserResponseDto(String email, String name) {
-    this.email = email;
-    this.name = name;
-  }
+	public UserResponseDto(Account account) {
+		this.email = account.getEmail();
+		this.name = account.getName();
+		this.birthday = account.getBirthday();
+		this.introduce = account.getIntroduce();
+		this.profileImageUrl = account.getProfileImageUrl();
+	}
+
 }

--- a/src/main/java/com/brick/demo/auth/entity/Account.java
+++ b/src/main/java/com/brick/demo/auth/entity/Account.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotEmpty;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,43 +27,60 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class Account {
 
-  @Id
-  @Column(name = "id")
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long entityId;
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long entityId;
 
-  @NotEmpty(message = "Name is required")
-  @Column(nullable = false, unique = true)
-  private String name;
+	@NotEmpty(message = "Name is required")
+	@Column(nullable = false, unique = true)
+	private String name;
 
-  @NotEmpty(message = "Email is required")
-  @Column(nullable = false, unique = true)
-  private String email;
+	@NotEmpty(message = "Email is required")
+	@Column(nullable = false, unique = true)
+	private String email;
 
-  @NotEmpty(message = "Password is required")
-  @Column(length = 60, nullable = false)
-  private String password;
+	@NotEmpty(message = "Password is required")
+	@Column(length = 60, nullable = false)
+	private String password;
 
-  @Enumerated(EnumType.STRING)
-  @Column(name = "oauth_provider")
-  private OAuthProvider oauthProvider;
+	private LocalDate birthday;
 
-  @CreatedDate
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private LocalDateTime createdAt;
+	private String introduce;
 
-  @LastModifiedDate
-  @Column(name = "updated_at", nullable = false)
-  private LocalDateTime updatedAt;
+	@Column(name = "profile_image_url")
+	private String profileImageUrl;
 
-  @Column(name = "deleted_at")
-  private LocalDateTime deletedAt;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "oauth_provider")
+	private OAuthProvider oauthProvider;
 
-  @Builder
-  public Account(String name, String email, String password, OAuthProvider oauthProvider) {
-    this.name = name;
-    this.email = email;
-    this.password = password;
-    this.oauthProvider = oauthProvider;
-  }
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Builder
+	public Account(String name, String email, String password, OAuthProvider oauthProvider) {
+		this.name = name;
+		this.email = email;
+		this.password = password;
+		this.oauthProvider = oauthProvider;
+	}
+
+	public void update(LocalDate birthday, String introduce, String profileImageUrl) {
+		this.birthday = birthday;
+		this.introduce = introduce;
+		this.profileImageUrl = profileImageUrl;
+	}
+	
+	public void softDelete() {
+		this.deletedAt = LocalDateTime.now();
+	}
 }


### PR DESCRIPTION
resolved #15 

## 작업 개요
- account 엔티티 수정.
- `/auth/users` PATCH, DELETE 구현

## 작업 사항
- 바뀐 기획에 맞추어서 Acccount 엔티티를 수정했습니다. nullable한 birthday, introduce, profileImageUrl를 추가했습니다
- `/auth/users` GET으로 유저 정보 가져오는 것 바뀐 account 엔티티 기준으로 수정했습니다. 
- `/auth/users` PATCH 로 유저정보를 수정할 수 있습니다. 이름은 수정하지 못하고, birthday, introduce, profileImageUrl 만 수정 가능하니다. 
- `/auth/users` DELETE 로 회원 탈퇴가 가능합니다. 탈퇴시 로그아웃처럼 access token, refresh token을 모두 삭제합니다. 탈퇴한 아이디로 로그인 시도 시, 탈퇴한 아이디라는 응답을 보내도록 했습니다. 


## 스크린샷(필수 X)
탈퇴한 아이디로 로그인 시도 시 보내는 응답입니다. 
<img width="966" alt="image" src="https://github.com/user-attachments/assets/a9d235d1-0de6-4105-b80c-dc763654d9a1">
