### PR TITLE
fix[#25]: access 토큰, 페이지네이션, soft-delete 수정

### DIFF
--- a/src/main/java/com/brick/demo/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/brick/demo/auth/jwt/TokenProvider.java
@@ -26,8 +26,8 @@ import org.springframework.stereotype.Component;
 public class TokenProvider {
 
 	public static final String BEARER_TYPE = "Bearer";
-	//  public static final String HEADER_STRING = "Authorization";
-	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+	private static final long ACCESS_TOKEN_EXPIRE_TIME =
+			1000 * 60 * 60 * 12; // 12시간 //TODO : 30분으로 바꾸기
 	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; //7일
 
 	private final Key key;

--- a/src/main/java/com/brick/demo/social/controller/QnaCommentController.java
+++ b/src/main/java/com/brick/demo/social/controller/QnaCommentController.java
@@ -6,7 +6,10 @@ import com.brick.demo.social.dto.QnaCommentRequestDto;
 import com.brick.demo.social.dto.QnaCommentResponseDto;
 import com.brick.demo.social.service.QnaCommentService;
 import jakarta.validation.Valid;
+import java.util.List;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,12 +32,18 @@ public class QnaCommentController implements QnaCommentControllerDocs {
 		this.qnaCommentService = qnaCommentService;
 	}
 
-	@GetMapping // qna id가 커서 (오래된순)
-	public PaginationIdResponse getCommentsByQnaId(@PathVariable Long socialId,
-			@PathVariable Long qnaId,
-			@RequestParam(value = "cursor", required = false) Long cursor,
-			@RequestParam(value = "limit") int limit) {
-		return qnaCommentService.getCommentsByQnaId(qnaId, cursor, limit);
+//	@GetMapping // qna id가 커서 (오래된순) - 커서기반
+//	public PaginationIdResponse getCommentsByQnaId(@PathVariable Long socialId,
+//			@PathVariable Long qnaId,
+//			@RequestParam(value = "cursor", required = false) Long cursor,
+//			@RequestParam(value = "limit") int limit) {
+//		return qnaCommentService.getCommentsByQnaId(qnaId, cursor, limit);
+//	}
+
+	@GetMapping // 오프셋 기반 페이지네이션
+	public ResponseEntity<List<QnaCommentResponseDto>> getCommentsByQnaId(@PathVariable Long socialId,
+			@PathVariable Long qnaId, @ParameterObject Pageable pageable) {
+		return qnaCommentService.getCommentsByQnaId(socialId, qnaId, pageable);
 	}
 
 	@PostMapping

--- a/src/main/java/com/brick/demo/social/controller/QnaCommentControllerDocs.java
+++ b/src/main/java/com/brick/demo/social/controller/QnaCommentControllerDocs.java
@@ -4,14 +4,19 @@ import com.brick.demo.social.dto.QnaCommentPatchDto;
 import com.brick.demo.social.dto.QnaCommentRequestDto;
 import com.brick.demo.social.dto.QnaCommentResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,6 +35,16 @@ public interface QnaCommentControllerDocs {
 	@PostMapping
 	QnaCommentResponseDto create(@PathVariable Long socialId, @PathVariable Long qnaId,
 			@Valid @RequestBody QnaCommentRequestDto dto);
+
+	@Operation(summary = "Qna 댓글 목록 조회", description = "특정 Qna의 댓글 목록을 생성일 오름차순으로 페이지네이션하여 조회합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "Qna 댓글 목록 조회 성공", content = @Content(array = @ArraySchema(schema = @Schema(implementation = QnaCommentResponseDto.class)))),
+			@ApiResponse(responseCode = "404", description = "해당하는 Qna ID의 Qna를 찾을 수 없습니다", content = @Content(schema = @Schema(hidden = true))),
+			@ApiResponse(responseCode = "400", description = "요청이 유효하지 않습니다", content = @Content(schema = @Schema(hidden = true))),
+	})
+	@GetMapping("/qnas/{socialId}/{qnaId}/comments")
+	ResponseEntity<List<QnaCommentResponseDto>> getCommentsByQnaId(
+			@PathVariable Long socialId, @PathVariable Long qnaId, @ParameterObject Pageable pageable);
 
 	@Operation(summary = "Qna 댓글 수정", description = "특정 Qna의 댓글을 수정합니다.")
 	@ApiResponses({

--- a/src/main/java/com/brick/demo/social/controller/QnaController.java
+++ b/src/main/java/com/brick/demo/social/controller/QnaController.java
@@ -8,9 +8,12 @@ import com.brick.demo.social.dto.QnaResponseDto;
 import com.brick.demo.social.service.QnaService;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -34,11 +37,18 @@ public class QnaController implements QnaControllerDocs {
 		this.qnaService = qnaService;
 	}
 
-	@GetMapping // qna created_at이 커서 (최신순)
-	public PaginationDateResponse getQnasBySocialIdOrderByLocalDate(@PathVariable Long socialId,
-			@RequestParam(value = "cursor", required = false) LocalDateTime cursor,
-			@RequestParam(value = "limit") int limit) {
-		return qnaService.getQnasBySocialIdByCreatedAt(socialId, cursor, limit);
+//	@GetMapping // qna created_at이 커서 (최신순) - 커서기반
+//	public PaginationDateResponse getQnasBySocialIdOrderByLocalDate(@PathVariable Long socialId,
+//			@RequestParam(value = "cursor", required = false) LocalDateTime cursor,
+//			@RequestParam(value = "limit") int limit) {
+//		return qnaService.getQnasBySocialIdByCreatedAt(socialId, cursor, limit);
+//	}
+
+	@GetMapping//오프셋 기반 페이지네이션
+	public ResponseEntity<List<QnaResponseDto>> getQnasBySocialIdOrderByLocalDate(
+			@PathVariable Long socialId,
+			@ParameterObject Pageable pageable) {
+		return qnaService.getQnasBySocialIdByCreatedAt(socialId, pageable);
 	}
 
 	@PostMapping

--- a/src/main/java/com/brick/demo/social/controller/QnaControllerDocs.java
+++ b/src/main/java/com/brick/demo/social/controller/QnaControllerDocs.java
@@ -4,14 +4,19 @@ import com.brick.demo.social.dto.QnaPatchRequestDto;
 import com.brick.demo.social.dto.QnaRequestDto;
 import com.brick.demo.social.dto.QnaResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,6 +35,16 @@ public interface QnaControllerDocs {
 	})
 	@PostMapping
 	QnaResponseDto create(@PathVariable Long socialId, @Valid @RequestBody QnaRequestDto dto);
+
+	@Operation(summary = "Qna 목록 조회", description = "특정 social의 Qna 목록을 생성일 내림차순으로 페이지네이션하여 조회합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "Qna 목록 조회 성공", content = @Content(array = @ArraySchema(schema = @Schema(implementation = QnaResponseDto.class)))),
+			@ApiResponse(responseCode = "404", description = "해당하는 social ID의 모임을 찾을 수 없습니다", content = @Content(schema = @Schema(hidden = true))),
+			@ApiResponse(responseCode = "400", description = "요청이 유효하지 않습니다", content = @Content(schema = @Schema(hidden = true))),
+	})
+	@GetMapping("/qnas/{socialId}")
+	ResponseEntity<List<QnaResponseDto>> getQnasBySocialIdOrderByLocalDate(
+			@PathVariable Long socialId, @ParameterObject Pageable pageable);
 
 	@Operation(summary = "Qna 수정", description = "특정 social의 Qna를 수정합니다.")
 	@ApiResponses({

--- a/src/main/java/com/brick/demo/social/repository/QnaCommentRepository.java
+++ b/src/main/java/com/brick/demo/social/repository/QnaCommentRepository.java
@@ -3,8 +3,12 @@ package com.brick.demo.social.repository;
 import com.brick.demo.common.repository.CommonPaginationRepository;
 import com.brick.demo.social.entity.Qna;
 import com.brick.demo.social.entity.QnaComment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QnaCommentRepository extends CommonPaginationRepository<QnaComment, Long> {
+
+	Page<QnaComment> findByQnaIdOrderByCreatedAtAsc(Long qnaId, Pageable pageable);
 
 }

--- a/src/main/java/com/brick/demo/social/repository/QnaCommentRepository.java
+++ b/src/main/java/com/brick/demo/social/repository/QnaCommentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QnaCommentRepository extends CommonPaginationRepository<QnaComment, Long> {
 
-	Page<QnaComment> findByQnaIdOrderByCreatedAtAsc(Long qnaId, Pageable pageable);
+	Page<QnaComment> findByQnaIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long qnaId, Pageable pageable);
+
 
 }

--- a/src/main/java/com/brick/demo/social/repository/QnaRepository.java
+++ b/src/main/java/com/brick/demo/social/repository/QnaRepository.java
@@ -4,6 +4,7 @@ import com.brick.demo.common.repository.CommonPaginationRepository;
 import com.brick.demo.social.entity.Qna;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +12,5 @@ import org.springframework.data.repository.query.Param;
 
 public interface QnaRepository extends CommonPaginationRepository<Qna, Long> {
 
+	Page<Qna> findBySocialIdOrderByCreatedAtDesc(Long socialId, Pageable pageable);
 }

--- a/src/main/java/com/brick/demo/social/repository/QnaRepository.java
+++ b/src/main/java/com/brick/demo/social/repository/QnaRepository.java
@@ -4,6 +4,7 @@ import com.brick.demo.common.repository.CommonPaginationRepository;
 import com.brick.demo.social.entity.Qna;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,5 +13,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface QnaRepository extends CommonPaginationRepository<Qna, Long> {
 
-	Page<Qna> findBySocialIdOrderByCreatedAtDesc(Long socialId, Pageable pageable);
+	// socialId를 기준으로 deleted_at이 null인 Qna 조회
+	Page<Qna> findBySocialIdAndDeletedAtIsNull(Long socialId, Pageable pageable);
+
+	// qnaId를 기준으로 deleted_at이 null인 Qna 조회
+	Optional<Qna> findByIdAndDeletedAtIsNull(Long qnaId);
 }

--- a/src/main/java/com/brick/demo/social/service/QnaCommentService.java
+++ b/src/main/java/com/brick/demo/social/service/QnaCommentService.java
@@ -9,10 +9,13 @@ import com.brick.demo.common.dto.PaginationIdResponse;
 import com.brick.demo.social.dto.QnaCommentPatchDto;
 import com.brick.demo.social.dto.QnaCommentRequestDto;
 import com.brick.demo.social.dto.QnaCommentResponseDto;
+import com.brick.demo.social.dto.QnaResponseDto;
 import com.brick.demo.social.entity.Qna;
 import com.brick.demo.social.entity.QnaComment;
 import com.brick.demo.social.repository.QnaCommentRepository;
 import com.brick.demo.social.repository.QnaRepository;
+import com.brick.demo.social.repository.SocialRepository;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -20,7 +23,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,22 +36,40 @@ public class QnaCommentService {
 	private final QnaCommentRepository qnaCommentRepository;
 	private final AccountRepository accountRepository;
 	private final QnaRepository qnaRepository;
+	private final SocialRepository socialRepository;
 
-	@Transactional
-	public PaginationIdResponse getCommentsByQnaId(Long qnaId, Long cursor, int limit) {
-		Map<String, Object> conditions = new HashMap<>();
-		conditions.put("qna.id", qnaId);
-		List<QnaComment> comments = qnaCommentRepository.findByCursorAndOrderByField(cursor, limit,
-				conditions, "id", true);
-		boolean hasNext = comments.size() > limit;
-		if (hasNext) {
-			comments = comments.subList(0, limit); // 필요한 만큼만 반환
-		}
-		List<QnaCommentResponseDto> commentResponseDtos = comments.stream()
+//	@Transactional
+//	public PaginationIdResponse getCommentsByQnaId(Long qnaId, Long cursor, int limit) {
+//		Map<String, Object> conditions = new HashMap<>();
+//		conditions.put("qna.id", qnaId);
+//		List<QnaComment> comments = qnaCommentRepository.findByCursorAndOrderByField(cursor, limit,
+//				conditions, "id", true);
+//		boolean hasNext = comments.size() > limit;
+//		if (hasNext) {
+//			comments = comments.subList(0, limit); // 필요한 만큼만 반환
+//		}
+//		List<QnaCommentResponseDto> commentResponseDtos = comments.stream()
+//				.map(QnaCommentResponseDto::new)
+//				.collect(Collectors.toList());
+//		Long nextCursor = hasNext ? comments.get(limit - 1).getId() : null;
+//		return new PaginationIdResponse(nextCursor, commentResponseDtos);
+//	}
+
+	public ResponseEntity<List<QnaCommentResponseDto>> getCommentsByQnaId(Long socialId, Long qnaId,
+			Pageable pageable) {
+		socialRepository.findById(socialId).orElseThrow(
+				() -> new CustomException(HttpStatus.NOT_FOUND, "해당하는 Social ID의 Social를 찾을 수 없습니다"));
+		qnaRepository.findById(qnaId)
+				.orElseThrow(
+						() -> new CustomException(HttpStatus.NOT_FOUND, "해당하는 Qna ID의 Qna를 찾을 수 없습니다"));
+
+		Page<QnaComment> qnaCommentPage = qnaCommentRepository.findByQnaIdOrderByCreatedAtAsc(qnaId,
+				pageable);
+
+		List<QnaCommentResponseDto> qnaCommentResponseDtos = qnaCommentPage.getContent().stream()
 				.map(QnaCommentResponseDto::new)
 				.collect(Collectors.toList());
-		Long nextCursor = hasNext ? comments.get(limit - 1).getId() : null;
-		return new PaginationIdResponse(nextCursor, commentResponseDtos);
+		return new ResponseEntity<>(qnaCommentResponseDtos, HttpStatus.OK);
 	}
 
 	@Transactional

--- a/src/main/java/com/brick/demo/social/service/QnaCommentService.java
+++ b/src/main/java/com/brick/demo/social/service/QnaCommentService.java
@@ -59,11 +59,12 @@ public class QnaCommentService {
 			Pageable pageable) {
 		socialRepository.findById(socialId).orElseThrow(
 				() -> new CustomException(HttpStatus.NOT_FOUND, "해당하는 Social ID의 Social를 찾을 수 없습니다"));
-		qnaRepository.findById(qnaId)
+		qnaRepository.findByIdAndDeletedAtIsNull(qnaId)
 				.orElseThrow(
 						() -> new CustomException(HttpStatus.NOT_FOUND, "해당하는 Qna ID의 Qna를 찾을 수 없습니다"));
 
-		Page<QnaComment> qnaCommentPage = qnaCommentRepository.findByQnaIdOrderByCreatedAtAsc(qnaId,
+		Page<QnaComment> qnaCommentPage = qnaCommentRepository.findByQnaIdAndDeletedAtIsNullOrderByCreatedAtAsc(
+				qnaId,
 				pageable);
 
 		List<QnaCommentResponseDto> qnaCommentResponseDtos = qnaCommentPage.getContent().stream()

--- a/src/main/java/com/brick/demo/social/service/QnaService.java
+++ b/src/main/java/com/brick/demo/social/service/QnaService.java
@@ -62,8 +62,8 @@ public class QnaService {
 			Pageable pageable) {
 		socialRepository.findById(socialId).orElseThrow(
 				() -> new CustomException(HttpStatus.NOT_FOUND, "해당하는 Social ID의 Social를 찾을 수 없습니다"));
-		
-		Page<Qna> qnaPage = qnaRepository.findBySocialIdOrderByCreatedAtDesc(socialId, pageable);
+
+		Page<Qna> qnaPage = qnaRepository.findBySocialIdAndDeletedAtIsNull(socialId, pageable);
 
 		List<QnaResponseDto> qnaResponseDtos = qnaPage.getContent().stream()
 				.map(qna -> new QnaResponseDto(qna, qna.getCommentCount()))

--- a/src/main/java/com/brick/demo/social/service/QnaService.java
+++ b/src/main/java/com/brick/demo/social/service/QnaService.java
@@ -25,7 +25,10 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -38,22 +41,37 @@ public class QnaService {
 	private final QnaCommentRepository qnaCommentRepository;
 	private final SocialRepository socialRepository;
 
-	public PaginationDateResponse getQnasBySocialIdByCreatedAt(Long socialId, LocalDateTime cursor,
-			int limit) {
-		Map<String, Object> conditions = new HashMap<>();
-		conditions.put("social.id", socialId);
-		List<Qna> qnas = qnaRepository.findByCursorAndOrderByCreatedAtDesc(cursor, limit,
-				conditions);
-		boolean hasNext = qnas.size() > limit;
-		if (hasNext) {
-			qnas = qnas.subList(0, limit); // 필요한 만큼만 반환
-		}
-		List<QnaResponseDto> qnaResponseDtos = qnas.stream()
+//	public PaginationDateResponse getQnasBySocialIdByCreatedAt(Long socialId, LocalDateTime cursor,
+//			int limit) {
+//		Map<String, Object> conditions = new HashMap<>();
+//		conditions.put("social.id", socialId);
+//		List<Qna> qnas = qnaRepository.findByCursorAndOrderByCreatedAtDesc(cursor, limit,
+//				conditions);
+//		boolean hasNext = qnas.size() > limit;
+//		if (hasNext) {
+//			qnas = qnas.subList(0, limit); // 필요한 만큼만 반환
+//		}
+//		List<QnaResponseDto> qnaResponseDtos = qnas.stream()
+//				.map(qna -> new QnaResponseDto(qna, qna.getCommentCount()))
+//				.collect(Collectors.toList());
+//		LocalDateTime nextCursor = hasNext ? qnas.get(limit - 1).getCreatedAt() : null;
+//		return new PaginationDateResponse(nextCursor, qnaResponseDtos);
+//	}
+
+	public ResponseEntity<List<QnaResponseDto>> getQnasBySocialIdByCreatedAt(Long socialId,
+			Pageable pageable) {
+		socialRepository.findById(socialId).orElseThrow(
+				() -> new CustomException(HttpStatus.NOT_FOUND, "해당하는 Social ID의 Social를 찾을 수 없습니다"));
+		
+		Page<Qna> qnaPage = qnaRepository.findBySocialIdOrderByCreatedAtDesc(socialId, pageable);
+
+		List<QnaResponseDto> qnaResponseDtos = qnaPage.getContent().stream()
 				.map(qna -> new QnaResponseDto(qna, qna.getCommentCount()))
 				.collect(Collectors.toList());
-		LocalDateTime nextCursor = hasNext ? qnas.get(limit - 1).getCreatedAt() : null;
-		return new PaginationDateResponse(nextCursor, qnaResponseDtos);
+
+		return new ResponseEntity<>(qnaResponseDtos, HttpStatus.OK);
 	}
+
 
 	@Transactional
 	public QnaResponseDto create(Long socialId, @Valid QnaRequestDto dto) {


### PR DESCRIPTION
resolved #25 

## 작업 개요
- access 토큰 시간 연장 (30분 -> 12시간)
- 페이지네이션 오프셋 기반으로 수정
-  deleted_at null 여부로 GET 요청할 때 삭제로 판단하고 가져오지 않도록 수정

## 작업 사항
- 작업 개요와 동일합니다.
- 포스트맨, 스웨거로 모두 동작 확인했습니다. 
